### PR TITLE
 fsperf: enhancements supporting read policy benchmark

### DIFF
--- a/local-cfg-example
+++ b/local-cfg-example
@@ -6,6 +6,12 @@ device=/dev/nvme0n1
 mkfs=mkfs.btrfs -f
 mount=mount -o noatime
 
+[btrfs-raid1]
+device=/dev/vg/scratch0
+mkfs=mkfs.btrfs -f -draid1 -mraid1 /dev/vg/scratch1
+mount=mount -o noatime
+readpolicy=pid
+
 [xfs]
 device=/dev/nvme0n1
 iosched=none

--- a/src/PerfTest.py
+++ b/src/PerfTest.py
@@ -9,7 +9,7 @@ class PerfTest():
     command = ""
     need_remount_after_setup = False
 
-    def setup(self, config):
+    def setup(self, config, section):
         pass
     def test(self, run, config, results):
         pass

--- a/src/fsperf.py
+++ b/src/fsperf.py
@@ -20,7 +20,7 @@ def run_test(args, session, config, section, test):
         mkfs(config, section)
         mount(config, section)
         try:
-            test.setup(config)
+            test.setup(config, section)
             if (test.need_remount_after_setup and
                 config.has_option(section, 'mount')):
                 run_command("umount {}".format(config.get('main', 'directory')))

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,6 +8,8 @@ import itertools
 import numbers
 import datetime
 import statistics
+import subprocess
+import re
 
 LOWER_IS_BETTER = 0
 HIGHER_IS_BETTER = 1
@@ -230,3 +232,50 @@ def print_comparison_table(baseline, results):
         table_rows.append(cur)
     table.add_rows(table_rows)
     print(table.draw())
+
+def get_fstype(device):
+    fstype = subprocess.check_output("blkid -s TYPE -o value "+device, shell=True)
+    # strip the output b'btrfs\n'
+    return (str(fstype).removesuffix("\\n'")).removeprefix("b'")
+
+def get_fsid(device):
+    fsid = subprocess.check_output("blkid -s UUID -o value "+device, shell=True)
+    # Raw output is something like this
+    #    b'abcf123f-7e95-40cd-8322-0d32773cb4ec\n'
+    # strip off extra characters.
+    return str(fsid)[2:38]
+
+def get_readpolicies(device):
+    fsid = get_fsid(device)
+    sysfs = open("/sys/fs/btrfs/"+fsid+"/read_policy", "r")
+    # Strip '[ ]' around the active policy
+    policies = (((sysfs.read()).strip()).strip("[")).strip("]")
+    sysfs.close()
+    return policies
+
+def get_active_readpolicy(device):
+    fsid = get_fsid(device)
+    sysfs = open("/sys/fs/btrfs/"+fsid+"/read_policy", "r")
+    policies = (sysfs.read()).strip()
+    # Output is as below, pick the policy within '[ ]'
+    #   device [pid] latency
+    active = re.search(r"\[([A-Za-z0-9_]+)\]", policies)
+    sysfs.close()
+    return active.group(1)
+
+def set_readpolicy(device, policy="pid"):
+    if not policy in get_readpolicies(device):
+        print("Read policy '{}' is invalid".format(policy))
+        sys.exit(1)
+        return
+    fsid = get_fsid(device)
+    # Ran out of ideas why run_command fails.
+    # command = "echo "+policy+" > /sys/fs/btrfs/"+fsid+"/read_policy"
+    # run_command(command)
+    sysfs = open("/sys/fs/btrfs/"+fsid+"/read_policy", "w")
+    ret = sysfs.write(policy)
+    sysfs.close()
+
+def has_readpolicy(device):
+    fsid = get_fsid(device)
+    return os.path.exists("/sys/fs/btrfs/"+fsid+"/read_policy")

--- a/tests/dio-randread.py
+++ b/tests/dio-randread.py
@@ -1,0 +1,28 @@
+import sys
+from PerfTest import FioTest
+from utils import get_fstype
+from utils import set_readpolicy
+from utils import get_active_readpolicy
+from utils import has_readpolicy
+
+class DioRandread(FioTest):
+    name = "diorandread"
+    command = ("--name diorandread --direct=1 --size=1g --rw=randread "
+               "--runtime=60 --iodepth=1024 --nrfiles=16 "
+               "--numjobs=16 --group_reporting")
+
+    def setup(self, config, section):
+        device = config.get(section, 'device')
+
+        if not get_fstype(device) == "btrfs":
+            return
+
+        if config.has_option(section, 'readpolicy'):
+            policy = config.get(section, 'readpolicy')
+            if not has_readpolicy(device):
+                print("Config:{} kernel does not support readpolicy", section)
+                sys.exit(1)
+
+            set_readpolicy(config.get(section, 'device'), policy)
+            policy = get_active_readpolicy(config.get(section, 'device'))
+            print("\tReadpolicy is set to '{}'".format(policy))

--- a/tests/randwrite-2xram.py
+++ b/tests/randwrite-2xram.py
@@ -9,6 +9,6 @@ class Randwrite2xRam(FioTest):
                "--size=SIZE --numjobs=4 --bs=4k --fsync_on_close=0 "
                "--end_fsync=0")
 
-    def setup(self, config):
+    def setup(self, config, section):
         mem = psutil.virtual_memory()
         self.command = self.command.replace('SIZE', str(mem.total*2))

--- a/tests/untar-firefox.py
+++ b/tests/untar-firefox.py
@@ -5,5 +5,5 @@ class UntarFirefox(TimeTest):
     name = "untarfirefox"
     command = "tar -xf firefox-87.0b5.source.tar.xz -C DIRECTORY"
 
-    def setup(self, config):
+    def setup(self, config, section):
         utils.run_command("wget -nc https://archive.mozilla.org/pub/firefox/releases/87.0b5/source/firefox-87.0b5.source.tar.xz")


### PR DESCRIPTION
Patch 1,2 adds helpers to support a new setup.
Patch 3 adds a generic readonly dio fio benchmark script.

How to run:
Manage the read policy in the config file as required.

For example:

```
$ cat local.cfg
    [main]
    directory=/mnt/test

    [btrfs-pid]
    device=/dev/vg/scratch0
    mkfs=mkfs.btrfs -f -draid1 -mraid1 /dev/vg/scratch1
    mount=mount -o noatime
    readpolicy=pid
    
    [btrfs-new-policy]
    device=/dev/vg/scratch0
    mkfs=mkfs.btrfs -f -draid1 -mraid1 /dev/vg/scratch1
    mount=mount -o noatime
    readpolicy=new-policy
```

```
$ ./fsperf -c btrfs-pid diorandread
snip
```

```
$ ./fsperf -c btrfs-new-policy -t -C btrfs-pid diorandread
snip
btrfs-new-policy test results
diorandread results
     metric         baseline   current    stdev         diff      
==================================================================
read_lat_ns_max     1.36e+08   1.09e+08       0   -20.02%
write_iops                 0          0       0     0.00%
read_clat_ns_p50     2277376    2244608       0    -1.44%
write_io_kbytes            0          0       0     0.00%
read_clat_ns_p99    12910592   11862016       0    -8.12%
write_bw_bytes             0          0       0     0.00%
read_iops            5680.85    5848.49       0     2.95%
write_clat_ns_p50          0          0       0     0.00%
read_io_bytes       1.40e+09   1.44e+09       0     2.95%
read_io_kbytes       1363496    1403708       0     2.95%
write_clat_ns_p99          0          0       0     0.00%
elapsed                   61         61       0     0.00%
read_bw_bytes       23268780   23955418       0     2.95%
sys_cpu                12.42      13.41       0     7.93%
write_lat_ns_min           0          0       0     0.00%
read_lat_ns_min       164944     189882       0    15.12%
write_lat_ns_max           0          0       0     0.00%
```