### PR TITLE
fsperf: fix disabled-tests file

### DIFF
--- a/disabled-tests
+++ b/disabled-tests
@@ -1,1 +1,1 @@
-500kemptyfiles
+EmptyFiles500k

--- a/src/fsperf.py
+++ b/src/fsperf.py
@@ -75,6 +75,7 @@ failed_tests = []
 with open('disabled-tests') as f:
     for line in f:
         disabled_tests.append(line.rstrip())
+        print("Disabled {}".format(line.rstrip()))
 
 sections = [args.config]
 if args.config is None:


### PR DESCRIPTION
disabled_tests in fsperf.py was testing __class__.__name__ while it was
specified following "name". Since it was already printing __name__, make
disabled match that, and also print what is disabled up front.

Signed-off-by: Boris Burkov <boris@bur.io>