### PR TITLE
fsperf: skip disabled in printing results

### DIFF
--- a/src/fsperf.py
+++ b/src/fsperf.py
@@ -142,6 +142,8 @@ if args.testonly:
         for t in tests:
             if len(args.tests) and t.name not in args.tests:
                 continue
+            if t.__class__.__name__ in disabled_tests:
+                continue
             results = utils.get_results(session, t.name, s, args.purpose, age)
             newest = []
             if compare_config:


### PR DESCRIPTION
When running with -t, we don't skip disabled tests in printing the
results. As a consequence, it crashes trying to pop a result from an
empty list and doesn't get to the rest of the tests.

Signed-off-by: Boris Burkov <boris@bur.io>