### PR TITLE
quick fix for bg scalability test

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -148,6 +148,7 @@ def want_mnt(test, config, section):
 class Mount:
     def __init__(self, test, config, section):
         self.live = False
+        self.want_mnt = False
         if want_mnt(test, config, section):
             self.want_mnt = True
             self.mount_cmd = config.get(section, 'mount')


### PR DESCRIPTION
the mount refactor had a dumb bug I forgot to pull back from my bg scalability test branch. I think it should work again, wherever the nullblk module logic works