### PR TITLE
Mount perf

### DIFF
--- a/fsperf-db/versions/006_mount_timing.py
+++ b/fsperf-db/versions/006_mount_timing.py
@@ -1,0 +1,21 @@
+from sqlalchemy import *
+from migrate import *
+
+meta = MetaData()
+
+mount_timing_table = Table(
+    "mount_timings", meta,
+    Column('id', Integer, primary_key=True),
+    Column('run_id', ForeignKey('runs.id', ondelete="CASCADE")),
+    Column('end_state_umount_ns', Integer, default=0),
+    Column('end_state_mount_ns', Integer, default=0),
+)
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    run_table = Table("runs", meta, autoload=True)
+    mount_timing_table.create()
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    mount_timing_table.drop()

--- a/src/PerfTest.py
+++ b/src/PerfTest.py
@@ -24,7 +24,7 @@ class PerfTest:
             mnt.cycle_mount()
 
     def run(self, run, config, section, results):
-        with utils.LatencyTracing(config, section, self) as lt:
+        with utils.LatencyTracing(self.what_latency_traces(config, section)) as lt:
             self.test(run, config, results)
         self.latency_traces = lt.results()
         self.collect_fragmentation(run, config)
@@ -72,6 +72,14 @@ class PerfTest:
                 self.fragmentation = {}
                 return
         self.fragmentation = json.load(open(frag_filename))
+
+    def what_latency_traces(self, config, section):
+        trace_fns = ""
+        if self.trace_fns:
+            trace_fns = self.trace_fns
+        elif config.has_option(section, 'trace_fns'):
+            trace_fns = config.get(section, 'trace_fns')
+        return [fn for fn in trace_fns.split(",") if fn]
 
 class FioTest(PerfTest):
     def record_results(self, run):

--- a/src/PerfTest.py
+++ b/src/PerfTest.py
@@ -3,7 +3,6 @@ import ResultData
 import utils
 import json
 from timeit import default_timer as timer
-from subprocess import Popen, PIPE, DEVNULL
 import contextlib
 
 RESULTS_DIR = "results"
@@ -15,6 +14,8 @@ class PerfTest:
     trace_fns = ""
     need_remount_after_setup = False
     skip_mkfs_and_mount = False
+    end_state_umount_s = 0
+    end_state_mount_s = 0
 
     # Set this if the test does something specific and isn't going to use the
     # configuration options to change how the test is run.
@@ -32,6 +33,7 @@ class PerfTest:
             self.latency_traces = lt.results()
             self.collect_fragmentation(run, config)
             self.commit_stats = utils.collect_commit_stats(config, section, run)
+            self.end_state_umount_s, self.end_state_mount_s = self.mnt.timed_cycle_mount()
             self.record_results(run)
 
     # do generic setup (mkfs/mount), then test-specific setup.
@@ -58,6 +60,8 @@ class PerfTest:
             ltr = ResultData.LatencyTrace()
             ltr.load_from_dict(lt)
             run.latency_traces.append(ltr)
+        mt = ResultData.MountTiming(self.end_state_umount_s, self.end_state_mount_s)
+        run.mount_timings.append(mt)
         f = ResultData.Fragmentation()
         f.load_from_dict(self.fragmentation)
         run.fragmentation.append(f)

--- a/src/PerfTest.py
+++ b/src/PerfTest.py
@@ -32,14 +32,14 @@ class PerfTest:
                 self.test(run, config, results)
             self.latency_traces = lt.results()
             self.collect_fragmentation(run, config)
-            self.commit_stats = utils.collect_commit_stats(config, section, run)
+            self.commit_stats = utils.collect_commit_stats(self.dev)
             self.end_state_umount_s, self.end_state_mount_s = self.mnt.timed_cycle_mount()
             self.record_results(run)
 
     # do generic setup (mkfs/mount), then test-specific setup.
     # use ExitStack to ensure we call umount/teardown appropriately
     def test_context(self, config, section):
-        utils.mkfs(self, config, section)
+        self.dev = utils.mkfs(self, config, section)
         stack = contextlib.ExitStack()
         if utils.want_mnt(self, config, section):
             self.mnt = utils.Mount(

--- a/src/ResultData.py
+++ b/src/ResultData.py
@@ -38,6 +38,9 @@ class Run(Base):
                                       backref="runs",
                                       order_by="BtrfsCommitStats.id",
                                       cascade="all,delete")
+    mount_timings = relationship("MountTiming", backref="runs",
+                                  order_by="MountTiming.id",
+                                  cascade="all,delete")
 
 def is_stat(key, value):
     return not "id" in key and isinstance(value, numbers.Number)
@@ -179,6 +182,20 @@ class BtrfsCommitStats(Base):
             if k not in inval:
                 continue
             setattr(self, k, inval[k])
+
+    def to_dict(self):
+        return result_to_dict(self)
+
+class MountTiming(Base):
+    __tablename__ = 'mount_timings'
+    id = Column(Integer, primary_key=True)
+    run_id = Column(ForeignKey('runs.id', ondelete="CASCADE"))
+    end_state_umount_ns = Column(Integer, default=0)
+    end_state_mount_ns = Column(Integer, default=0)
+
+    def __init__(self, umount, mount):
+        self.end_state_umount_ns = umount
+        self.end_state_mount_ns = mount
 
     def to_dict(self):
         return result_to_dict(self)

--- a/src/fsperf.py
+++ b/src/fsperf.py
@@ -43,20 +43,14 @@ def want_run_test(run_tests, disabled_tests, t):
 
 def run_test(args, session, config, section, purpose, test):
     for i in range(0, args.numruns):
-        mkfs(test, config, section)
-        with Mount(test, config, section) as mnt:
-            try:
-                test.setup(config, section)
-                test.maybe_cycle_mount(mnt)
-                run = ResultData.Run(kernel=platform.release(), config=section,
-                                     name=test.name, purpose=purpose)
-                test.run(run, config, section, "results")
-                session.add(run)
-                session.commit()
-            except NotRunException as e:
-                print("Not run: {}".format(e))
-            finally:
-                test.teardown(config, "results")
+        try:
+            run = ResultData.Run(kernel=platform.release(), config=section,
+                                 name=test.name, purpose=purpose)
+            test.run(run, config, section, "results")
+            session.add(run)
+            session.commit()
+        except NotRunException as e:
+            print("Not run: {}".format(e))
     return 0
 
 parser = argparse.ArgumentParser()

--- a/src/fsperf.py
+++ b/src/fsperf.py
@@ -168,9 +168,15 @@ if args.testonly:
         print(f"{section} test results")
         for t in tests:
             if not want_run_test(args.tests, disabled_tests, t):
-                print(f'skipping test {t.name}')
                 continue
             compare_section = compare_config if compare_config else section
             compare.compare_results(session, compare_section, section, t, args.purpose, TEST_ONLY, age)
+    if oneoffs:
+        print(f"oneoff test results")
+    for t in oneoffs:
+        if not want_run_test(args.tests, disabled_tests, t):
+            continue
+        compare_section = compare_config if compare_config else section
+        compare.compare_results(session, "oneoff", "oneoff", t, args.purpose, TEST_ONLY, age)
     # We use the db to uniformly access test results. Clean up testonly results
     clean_testonly(session, sections, tests)

--- a/src/utils.py
+++ b/src/utils.py
@@ -147,34 +147,30 @@ def want_mnt(test, config, section):
     return config.has_option(section, 'mount') and not test.skip_mkfs_and_mount
 
 class Mount:
-    def __init__(self, test, config, section):
+    def __init__(self, command, device, mount_point):
         self.live = False
-        self.want_mnt = False
-        if want_mnt(test, config, section):
-            self.want_mnt = True
-            self.mount_cmd = config.get(section, 'mount')
-            self.device = config.get(section, 'device')
-            self.mnt = config.get('main', 'directory')
+        self.device = device
+        self.mount_point = mount_point
+        self.mount_cmd = command
+        self.mount()
 
-    def do_mount(self):
-        if self.want_mnt:
-            run_command(f'{self.mount_cmd} {self.device} {self.mnt}')
-            self.live = True
+    def mount(self):
+        run_command(f'{self.mount_cmd} {self.device} {self.mount_point}')
+        self.live = True
 
-    def do_umount(self):
+    def umount(self):
         if self.live:
-            run_command(f"umount {self.mnt}")
+            run_command(f"umount {self.mount_point}")
 
     def cycle_mount(self):
-        self.do_umount()
-        self.do_mount()
+        self.umount()
+        self.mount()
 
     def __enter__(self):
-        self.do_mount()
         return self
 
     def __exit__(self, et, ev, etb):
-        self.do_umount()
+        self.umount()
         # re-raise
         if et is not None:
             return False

--- a/src/utils.py
+++ b/src/utils.py
@@ -180,18 +180,11 @@ class Mount:
             return False
 
 class LatencyTracing:
-    def __init__(self, config, section, test):
+    def __init__(self, fns):
         self.ps = {}
         self.latencies = {}
         self.calls = {}
-        self.fns = []
-        trace_fns = ""
-        if test.trace_fns:
-            trace_fns = test.trace_fns
-        elif config.has_option(section, 'trace_fns'):
-            trace_fns = config.get(section, 'trace_fns')
-        if len(trace_fns) > 0:
-            self.fns = trace_fns.split(",")
+        self.fns = fns
 
     def start_latency_trace(self, fn):
         # this sets the max size of a map in bpftrace

--- a/tests/btrfsbgscalability.py
+++ b/tests/btrfsbgscalability.py
@@ -13,8 +13,8 @@ class BtrfsBgScalability(FioTest):
 
     def teardown(self, config, results):
         directory = config.get('main', 'directory')
-        loopdir = f'{directory}/loop'
-        utils.run_command(f'umount {loopdir}')
+        self.mnt.umount()
+        self.nullb_mnt.umount()
         utils.run_command(f'umount {directory}')
         self.nullblk = None
 
@@ -32,12 +32,12 @@ class BtrfsBgScalability(FioTest):
             raise utils.NotRunException("We don't have nullblk support loaded")
 
         mkfsopts = "-f -R free-space-tree -O no-holes"
-        mntopts = "-o ssd,nodatacow"
+        mntcmd = "mount -o ssd,nodatacow"
 
         # First create the nullblk fs to load the loop device onto
         command = f'mkfs.btrfs {mkfsopts} /dev/nullb0'
         utils.run_command(command)
-        utils.run_command(f'mount {mntopts} /dev/nullb0 {directory}')
+        self.nullb_mnt = utils.Mount(mntcmd, '/dev/nullb0', directory)
 
         # Now create the loop device
         loopdir = f'{directory}/loop'
@@ -45,9 +45,9 @@ class BtrfsBgScalability(FioTest):
         utils.mkdir_p(f'{directory}/loop')
         utils.run_command(f'truncate -s 4T {loopfile}')
         utils.run_command(f'mkfs.btrfs {mkfsopts} {loopfile}')
-        utils.run_command(f'mount {mntopts} {loopfile} {loopdir}')
+        self.mnt = utils.Mount(mntcmd, loopfile, loopdir)
 
-        # Trigger teh allocation of about 3500 data block groups, without
+        # Trigger the allocation of about 3500 data block groups, without
         # actually consuming space on the underlying filesystem, just to make
         # the tree of block groups large
         utils.run_command(f'fallocate -l 3500G {loopdir}/filler')
@@ -56,8 +56,7 @@ class BtrfsBgScalability(FioTest):
     # the directory and want to use a different directory than the one we
     # mounted the nullblk ontop of
     def test(self, run, config, results):
-        directory = config.get('main', 'directory')
-        directory += "/loop"
+        directory = self.mnt.mount_point
         command = self.default_cmd(results)
         command += f' --directory {directory} '
         command += self.command

--- a/tests/btrfsbgscalability.py
+++ b/tests/btrfsbgscalability.py
@@ -45,6 +45,7 @@ class BtrfsBgScalability(FioTest):
         utils.mkdir_p(f'{directory}/loop')
         utils.run_command(f'truncate -s 4T {loopfile}')
         utils.run_command(f'mkfs.btrfs {mkfsopts} {loopfile}')
+        self.dev = loopfile
         self.mnt = utils.Mount(mntcmd, loopfile, loopdir)
 
         # Trigger the allocation of about 3500 data block groups, without

--- a/tests/btrfsbgscalability.py
+++ b/tests/btrfsbgscalability.py
@@ -15,7 +15,6 @@ class BtrfsBgScalability(FioTest):
         directory = config.get('main', 'directory')
         self.mnt.umount()
         self.nullb_mnt.umount()
-        utils.run_command(f'umount {directory}')
         self.nullblk = None
 
     def setup(self, config, section):
@@ -28,8 +27,8 @@ class BtrfsBgScalability(FioTest):
         self.nullblk.config_values = config_values
         try:
             self.nullblk.start()
-        except:
-            raise utils.NotRunException("We don't have nullblk support loaded")
+        except Exception as e:
+            raise utils.NotRunException(f"We don't have nullblk support loaded {e}")
 
         mkfsopts = "-f -R free-space-tree -O no-holes"
         mntcmd = "mount -o ssd,nodatacow"
@@ -62,5 +61,3 @@ class BtrfsBgScalability(FioTest):
         command += f' --directory {directory} '
         command += self.command
         utils.run_command(command)
-
-        self.record_results(run, results)


### PR DESCRIPTION
This stack adds a timed cycle mount at the end of each fsperf run.

At first I did it by latency tracing open_ctree/close_ctree but that was horrible for a few reasons, so switched to just timing the mount/umount commands.

It required some more refactoring to get the mount object visible to the test s.t. it could trigger a cycle mount on it after the test, even for the bg scalability test (which I think will be a good one for this timing)