### PR TITLE
show regression when baseline is zero

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -313,8 +313,11 @@ def avg_results(results):
     return ret_dict
 
 def pct_diff(a, b):
-    if a == 0:
+    if a == 0 and b == 0:
         return 0
+    # kind of silly, but renders reasonably well
+    if a == 0:
+        return 100
     return ((b - a) / a) * 100
 
 def color_str(s, color):
@@ -383,9 +386,9 @@ def print_comparison_table(baseline, results):
     table.set_cols_align(['l', 'r', 'r', 'r', 'r'])
     table_rows = [["metric", "baseline", "current", "stdev", "diff"]]
     for k,v in sorted(baseline.items()):
-        if not v['mean']:
-            continue
         if k not in results:
+            continue
+        if not v['mean'] and not results[k]['mean']:
             continue
         better = metric_direction(k)
         diff_str = diff_string(v, results[k], better)


### PR DESCRIPTION
Instead of skipping all keys where the mean is zero (generally fine for fio jobs that don't do one of read/write and always have zero), only skip the ones where both the baseline and the experiment are zero. Otherwise, it is a regression/improvement. In practice this really shows up in the fragmentation metrics, but theoretically could show up in a latency trace or even fio metric.