### PR TITLE
add test measuring synced log write performance

### DIFF
--- a/tests/buffered-append-sync.py
+++ b/tests/buffered-append-sync.py
@@ -1,0 +1,6 @@
+from PerfTest import FioTest
+
+class Bufferedappendsync(FioTest):
+    name = "bufferedappenddatasync"
+    command = ("--name bufferedappendsync --direct=0 --size=1g --rw=write "
+               "--fdatasync=1 --ioengine=sync")


### PR DESCRIPTION
This test measures the performance of small persisted writes to a log (e.g. the RocksDB WAL)

This benchmark is very heavy on metadata and provides a good metric for that kind of overhead.
It is relevant for real-world use cases where records stored a write-ahead-log needs to be persisted (e.g transactions)
