### PR TITLE
add block device io read/write stats

### DIFF
--- a/fsperf-db/versions/007_io_stats.py
+++ b/fsperf-db/versions/007_io_stats.py
@@ -1,0 +1,23 @@
+from sqlalchemy import *
+from migrate import *
+
+meta = MetaData()
+
+dev_iostats_table = Table(
+    "io_stats", meta,
+    Column('id', Integer, primary_key=True),
+    Column('run_id', ForeignKey('runs.id', ondelete="CASCADE")),
+    Column('dev_read_iops', Integer, default=0),
+    Column('dev_read_kbytes', Integer, default=0),
+    Column('dev_write_iops', Integer, default=0),
+    Column('dev_write_kbytes', Integer, default=0)
+)
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    run_table = Table("runs", meta, autoload=True)
+    dev_iostats_table.create()
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    dev_iostats_table.drop()

--- a/src/ResultData.py
+++ b/src/ResultData.py
@@ -34,6 +34,9 @@ class Run(Base):
     latency_traces = relationship("LatencyTrace", backref="runs",
                                   order_by="LatencyTrace.id",
                                   cascade="all,delete")
+    io_stats = relationship("IOStats", backref="runs",
+                            order_by="IOStats.id",
+                            cascade="all,delete")
     btrfs_commit_stats = relationship("BtrfsCommitStats",
                                       backref="runs",
                                       order_by="BtrfsCommitStats.id",
@@ -136,6 +139,24 @@ class Fragmentation(Base):
     frag_pct_p95 = Column(Float, default=0.0)
     frag_pct_p99 = Column(Float, default=0.0)
     frag_pct_max = Column(Float, default=0.0)
+
+    def load_from_dict(self, inval):
+        for k in dir(self):
+            if k not in inval:
+                continue
+            setattr(self, k, inval[k])
+
+    def to_dict(self):
+        return result_to_dict(self)
+
+class IOStats(Base):
+    __tablename__ = 'io_stats'
+    id = Column(Integer, primary_key=True)
+    run_id = Column(ForeignKey('runs.id', ondelete="CASCADE"))
+    dev_read_iops = Column(Integer, default=0)
+    dev_read_kbytes = Column(Integer, default=0)
+    dev_write_iops = Column(Integer, default=0)
+    dev_write_kbytes = Column(Integer, default=0)
 
     def load_from_dict(self, inval):
         for k in dir(self):

--- a/src/clean-results.py
+++ b/src/clean-results.py
@@ -29,6 +29,7 @@ for p in args.labels:
             outerjoin(TimeResult).\
             outerjoin(Fragmentation).\
             outerjoin(LatencyTrace).\
+            outerjoin(IOStats).\
             outerjoin(BtrfsCommitStats).\
             outerjoin(MountTiming).\
             filter(Run.purpose == p).all()
@@ -43,6 +44,7 @@ if args.test is not None:
             outerjoin(TimeResult).\
             outerjoin(Fragmentation).\
             outerjoin(LatencyTrace).\
+            outerjoin(IOStats).\
             outerjoin(BtrfsCommitStats).\
             outerjoin(MountTiming).\
             filter(Run.name == args.test).all()
@@ -57,6 +59,7 @@ if args.config is not None:
             outerjoin(TimeResult).\
             outerjoin(Fragmentation).\
             outerjoin(LatencyTrace).\
+            outerjoin(IOStats).\
             outerjoin(BtrfsCommitStats).\
             outerjoin(MountTiming).\
             filter(Run.config == args.config).all()

--- a/src/generate-results-page.py
+++ b/src/generate-results-page.py
@@ -20,6 +20,7 @@ def get_avgs(session, config, test, days):
         outerjoin(TimeResult).\
         outerjoin(Fragmentation).\
         outerjoin(LatencyTrace).\
+        outerjoin(IOStats).\
         outerjoin(BtrfsCommitStats).\
         outerjoin(MountTiming).\
         filter(Run.time >= thresh).\
@@ -48,6 +49,7 @@ def get_last(session, config, test):
         outerjoin(TimeResult).\
         outerjoin(Fragmentation).\
         outerjoin(LatencyTrace).\
+        outerjoin(IOStats).\
         outerjoin(BtrfsCommitStats).\
         outerjoin(MountTiming).\
         filter(Run.name == test).\
@@ -69,6 +71,7 @@ def get_all_results(session, config, test):
         outerjoin(TimeResult).\
         outerjoin(Fragmentation).\
         outerjoin(LatencyTrace).\
+        outerjoin(IOStats).\
         outerjoin(BtrfsCommitStats).\
         outerjoin(MountTiming).\
         filter(Run.name == test).\


### PR DESCRIPTION
Get the blkdev io stats before and after running a test to measure read and write ios submitted by the file system to the backing block device.

Together with stats reported by e.g fio(read/write_io_kbytes  read/write_iops) read and write amplification can be calculated, providing a good metric for file system IO overhead (metadata, garbage collection etc)
