### PR TITLE
add before and after commands

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -119,6 +119,11 @@ def run_command(cmd, outputfile=None):
         print(f"{cmd} failed. out: {out}, err: {err}")
         raise CalledProcessError(p.returncode, cmd)
 
+def run_bg_command(cmd, outputfile=None):
+    print(f"  running cmd '{cmd}'")
+    p = Popen(shlex.split(cmd), stdout=DEVNULL, stderr=DEVNULL)
+    return p
+
 def setup_cpu_governor(config):
     if not config.has_option('main', 'cpugovernor'):
         return


### PR DESCRIPTION
Add before and after options to local.cfg. The before command gets run in the background before the test is run, and killed after the test is finished. The after command gets run after the before command is killed.

So if you want to run tests while balance is running in a loop, you can do the following:
```
[main]
directory=/root/temp

[btrfs]
device=/dev/loop11
mkfs=mkfs.btrfs -f
mount=mount -o noatime
before=bash -c "while true; do btrfs balance start -d -m /root/temp; done"
after=btrfs balance cancel /root/temp
```