### PR TITLE
kill before command and run after command even if test fails

### DIFF
--- a/src/PerfTest.py
+++ b/src/PerfTest.py
@@ -32,15 +32,16 @@ class PerfTest:
             if config.has_option(section, 'before'):
                 bg_proc = utils.run_bg_command(config.get(section, 'before'))
 
-            with utils.IOStats(self.dev) as ios:
-                with utils.LatencyTracing(self.what_latency_traces(config, section)) as lt:
-                    self.test(run, config, results)
+            try:
+                with utils.IOStats(self.dev) as ios:
+                    with utils.LatencyTracing(self.what_latency_traces(config, section)) as lt:
+                        self.test(run, config, results)
+            finally:
+                if config.has_option(section, 'before'):
+                    bg_proc.kill()
 
-            if config.has_option(section, 'before'):
-                bg_proc.kill()
-
-            if config.has_option(section, 'after'):
-                utils.run_command(config.get(section, 'after'))
+                if config.has_option(section, 'after'):
+                    utils.run_command(config.get(section, 'after'))
 
             self.io_stats = ios.results()
             self.latency_traces = lt.results()


### PR DESCRIPTION
Put the "after" code in a finally block, so it runs even if the test throws an exception. This means e.g. that a balance won't run indefinitely because the test caused an ENOSPC, etc.